### PR TITLE
Fix #4: Crash when loading unknown setting

### DIFF
--- a/BibitinatorMain.cs
+++ b/BibitinatorMain.cs
@@ -225,7 +225,7 @@ namespace Bibitinator
                 settingsDictionary.setting setting;
                                                                            //- V Find the setting with the same name
                 setting = knownSettings.Find(x => x.internalName == ((JProperty)prop).Name);
-                if (setting.internalLocation != String.Empty)
+                if (setting?.internalLocation != String.Empty)
                 {                                          //----------------- ^ if the setting is a property of an obj, make sure the targeted setting has the correct parent obj
                     setting = setting = knownSettings.Find(x => x.internalName == ((JProperty)prop).Name && ((JProperty)prop.Parent.Parent).Name == x.internalLocation);
                 }


### PR DESCRIPTION
The check for `setting.internalLocation` should probably be moved to after the `if (setting == null)` call. But for now changing it to a `?.` null-conditional operator works.

This fixes issue #4